### PR TITLE
Minor typo in index entry

### DIFF
--- a/vignettes/parglm.html.asis
+++ b/vignettes/parglm.html.asis
@@ -1,2 +1,2 @@
-%\VignetteIndexEntry{Introduction to the paglm package}
+%\VignetteIndexEntry{Introduction to the parglm package}
 %\VignetteEngine{R.rsp::asis}


### PR DESCRIPTION
I just spotted this at https://cran.r-project.org/web/packages/parglm/index.html when I followed your new package (as I try to follow Rcpp reverse dependencies).  

Congrats on getting it onto CRAN!