### PR TITLE
Switch DOUBLE_EPS to DBL_EPSILON to support STRICT_R_HEADERS

### DIFF
--- a/src/family.cpp
+++ b/src/family.cpp
@@ -48,7 +48,7 @@ double binomial_logit::dev_resids(double y, double mu, double wt) const {
 double binomial_logit::mu_eta(double eta) const {
   double opexp = 1 + exp(eta);
 
-  return (eta > THRESH || eta < MTHRESH) ? DOUBLE_EPS :
+  return (eta > THRESH || eta < MTHRESH) ? DBL_EPSILON :
     exp(eta)/(opexp * opexp);
 }
 


### PR DESCRIPTION
Hi Ben,

The Rcpp team is trying to move towards defining STRICT_R_HEADERS by default. Please the issue ticket at https://github.com/RcppCore/Rcpp/issues/1158 for motivation and history.

Your package uses (in one file, once) DOUBLE_EPS but when STRICT_R_HEADERS is in use the equivalent DBL_EPSILON is preferred. You can set STRICT_R_HEADERS as a #define in a header or source file, via -DSTRICT_R_HEADERS as a compiler flag, or as a #define in the Rcpp sources as we currently do. We plan to enable STRICT_R_HEADERS by the Jan 2022 release of Rcpp, and will likely offer you a define to suppress it. So if you really do not want the change you can prevent it -- see these lines in Rcpp for details:
https://github.com/RcppCore/Rcpp/blob/e79c70e76bc2a776d2d57287f7192dbdbcb292aa/inst/include/Rcpp/r/headers.h#L28-L38

Of course, you can probably also switch to `std::numeric_limits<double>::epsilon())` as you already do.

This very simple PR changes one DOUBLE_EPS to DBL_EPSILON. Your code will then work with and without STRICT_R_HEADERS as we now include cfloat. To be really safe against older Rcpp release you may want to include it to (or the equivalent float.h). In your case, might be easiest in one common header that defines the tolerance constant.

As discussed in https://github.com/RcppCore/Rcpp/issues/1158, this is not urgent, but we of course welcome relatively prompt resolution at CRAN so when we continue to test for this (at a likely montly pace) so we do not get false positives as we will continue to use the CRAN set of packages (as opposed to hand-curated set of upstream dev versions).

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.