### PR TITLE
Remove obsolete CXX_STD = CXX11 to allow Armadillo 15.0.x migration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ URL: https://github.com/boennecd/parglm
 BugReports: https://github.com/boennecd/parglm/issues
 LinkingTo: Rcpp, RcppArmadillo
 Imports: Rcpp, Matrix
-SystemRequirements: C++11
 Suggests: testthat, 
     SuppDists,
     knitr,


### PR DESCRIPTION
Armadillo 15.0.* now makes C++14 the minimum compilation standard. For most packages, adapting to it can be very simple, and yours is one of them. In this PR we simply remove the declaration from DESCRIPTION -- and no other changes are needed. (I noticed in my fork that the GH Action failed, it appears to be a bit dated. As I use a [the much simpler setup `r-ci`](https://eddelbuettel.github.io/r-ci/) I made no change but I would be happy to provide a simpler, more robust CI script (albeit without Windows or old versions: I rely on r-universe there). Let me if that would help.)

Please see issues [#475](https://github.com/RcppCore/RcppArmadillo/issues/475) and below for context, and notably [#489](https://github.com/RcppCore/RcppArmadillo/issues/489) for this first wave of PRs. It would be terrific if you could make an upload to CRAN 'soon' to remove the reliance on C++11 which we needed in the past, but which is by now a hindrance. Please do not hesitate to reach out if I can assist in any way or clarify matters.

/cc @kurthornik

PS Just for kicks I opened a branch with a simpler `ci.yaml`, you can see the successful run [here](https://github.com/eddelbuettel/parglm/actions/runs/17880763889/job/50848110592)